### PR TITLE
Fix implicit integer conversion warnings with clang-21

### DIFF
--- a/z80/common/Alu.cpp
+++ b/z80/common/Alu.cpp
@@ -32,7 +32,7 @@ Alu::R8 Alu::add8(const std::uint8_t lhs, const std::uint8_t rhs, const bool car
 }
 
 Alu::R8 Alu::sub8(const std::uint8_t lhs, const std::uint8_t rhs, const bool carry_in) {
-  const auto [result, flags] = add8(lhs, ~rhs, !carry_in);
+  const auto [result, flags] = add8(lhs, static_cast<std::uint8_t>(~rhs), !carry_in);
   return {result, (flags | Flags::Subtract()) ^ Flags::Carry() ^ Flags::HalfCarry()};
 }
 
@@ -66,7 +66,7 @@ Alu::R16 Alu::add16(const std::uint16_t lhs, const std::uint16_t rhs, const Flag
 }
 
 Alu::R16 Alu::sub16(const std::uint16_t lhs, const std::uint16_t rhs, const Flags current_flags) {
-  const auto [result, flags] = add16(lhs, ~rhs, current_flags);
+  const auto [result, flags] = add16(lhs, static_cast<std::uint16_t>(~rhs), current_flags);
   return {result, (flags | Flags::Subtract()) ^ Flags::Carry() ^ Flags::HalfCarry()};
 }
 
@@ -83,7 +83,7 @@ Alu::R16 Alu::adc16(const std::uint16_t lhs, const std::uint16_t rhs, const bool
 }
 
 Alu::R16 Alu::sbc16(const std::uint16_t lhs, const std::uint16_t rhs, const bool carry_in) {
-  const auto [result, flags] = adc16(lhs, ~rhs, !carry_in);
+  const auto [result, flags] = adc16(lhs, static_cast<std::uint16_t>(~rhs), !carry_in);
   return {result, (flags | Flags::Subtract()) ^ Flags::Carry() ^ Flags::HalfCarry()};
 }
 

--- a/z80/common/include/z80/common/Flags.hpp
+++ b/z80/common/include/z80/common/Flags.hpp
@@ -17,7 +17,7 @@ public:
   constexpr Flags operator&(const Flags rhs) const { return Flags(value_ & rhs.value_); }
   constexpr Flags operator|(const Flags rhs) const { return Flags(value_ | rhs.value_); }
   constexpr Flags operator^(const Flags rhs) const { return Flags(value_ ^ rhs.value_); }
-  constexpr Flags operator~() const { return Flags(~value_); }
+  constexpr Flags operator~() const { return Flags(static_cast<std::uint8_t>(~value_)); }
 
   [[nodiscard]] static constexpr Flags Carry() { return Flags(Flag::carry); }
   [[nodiscard]] static constexpr Flags Subtract() { return Flags(Flag::subtract); }


### PR DESCRIPTION
## Summary
- Fixes implicit integer conversion warnings when building with clang-21.1.0
- Adds explicit static_cast for bitwise NOT operations on uint8_t and uint16_t
- All tests pass with clang-21.1.0

## Details
Clang-21 is stricter about implicit integer conversions than clang-20. The bitwise NOT operator (`~`) on `uint8_t`/`uint16_t` promotes to `int` due to C++ integer promotion rules, requiring explicit casts back to the smaller types.

## Changes
Fixed in 4 locations:
- `Flags::operator~()`: Added `static_cast<std::uint8_t>`
- `Alu::sub8()`: Added `static_cast<std::uint8_t>` for `~rhs`
- `Alu::sub16()`: Added `static_cast<std::uint16_t>` for `~rhs`
- `Alu::sbc16()`: Added `static_cast<std::uint16_t>` for `~rhs`

## Test plan
- [x] Build succeeds with clang-21.1.0 and modules disabled
- [x] All 6 test suites pass (peripheral, z80 v1/v2/v3, common)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)