### PR TITLE
Add CMake presets, auto-rpath libc++, migrate CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         preset: [ debug, debug-modules, release, release-modules ]
         clang_version: [ 20 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: setup system dependencies
         run: |
           sudo apt update -y
@@ -19,7 +19,7 @@ jobs:
         with:
           cmake-version: '3.30.x'
       - name: Install ninja-build tool
-        uses: seanmiddleditch/gha-setup-ninja@v5
+        uses: seanmiddleditch/gha-setup-ninja@v6
       - name: install clang
         run: |
           wget https://apt.llvm.org/llvm.sh
@@ -50,7 +50,7 @@ jobs:
       - name: Print Clang version
         run: echo $(brew --prefix llvm)/bin/clang++ --version
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Configure
         run: |
           cmake --preset ${{ matrix.preset }} \
@@ -69,13 +69,13 @@ jobs:
       matrix:
         clang_version: [ 20 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.30.x'
       - name: Install ninja-build tool
-        uses: seanmiddleditch/gha-setup-ninja@v5
+        uses: seanmiddleditch/gha-setup-ninja@v6
       - name: install clang
         run: |
           wget https://apt.llvm.org/llvm.sh
@@ -97,7 +97,7 @@ jobs:
           cmake --install build/wasm
       - name: Deploy
         if: github.ref == 'refs/heads/main'
-        uses: jakejarvis/s3-sync-action@master
+        uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --cache-control max-age=30 --metadata-directive REPLACE
         env:
@@ -109,5 +109,5 @@ jobs:
   check-pre-commits:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build_type: [ Debug, RelWithDebInfo ]
+        preset: [ debug, debug-modules, release, release-modules ]
         clang_version: [ 20 ]
-        modules_enable: [ ON, OFF ]
     steps:
       - uses: actions/checkout@v4
       - name: setup system dependencies
@@ -27,21 +26,18 @@ jobs:
           sudo bash llvm.sh ${{ matrix.clang_version }} all
           echo "CC=clang-${{ matrix.clang_version }}" >> "$GITHUB_ENV"
           echo "CXX=clang++-${{ matrix.clang_version }}" >> "$GITHUB_ENV"
+      - name: Configure
+        run: cmake --preset ${{ matrix.preset }}
       - name: Build
-        run: |
-          mkdir build
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DSPECBOLT_MODULES=${{ matrix.modules_enable }}
-          cmake --build build
+        run: cmake --build --preset ${{ matrix.preset }}
       - name: Test
-        run: |
-          env CTEST_PARALLEL_LEVEL=$(nproc) CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --target test
+        run: env CTEST_PARALLEL_LEVEL=$(nproc) ctest --preset ${{ matrix.preset }}
 
   mac-build-and-test:
     runs-on: macos-15
     strategy:
       matrix:
-        build_type: [ Debug, RelWithDebInfo ]
-        modules_enable: [ ON, OFF ]
+        preset: [ debug, debug-modules, release, release-modules ]
     steps:
       - name: Select latest XCode
         run: |
@@ -55,21 +51,23 @@ jobs:
         run: echo $(brew --prefix llvm)/bin/clang++ --version
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Configure
+        run: |
+          cmake --preset ${{ matrix.preset }} \
+            -DCMAKE_C_COMPILER="$(brew --prefix llvm)/bin/clang" \
+            -DCMAKE_CXX_COMPILER="$(brew --prefix llvm)/bin/clang++" \
+            -DCMAKE_SYSROOT="$(xcrun --show-sdk-path)" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
       - name: Build
-        run: |
-          cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER="$(brew --prefix llvm)/bin/clang" -DCMAKE_CXX_COMPILER="$(brew --prefix llvm)/bin/clang++" -DCMAKE_SYSROOT="$(xcrun --show-sdk-path)" -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DSPECBOLT_MODULES=${{ matrix.modules_enable }}
-          cmake --build build
+        run: cmake --build --preset ${{ matrix.preset }}
       - name: Test
-        run: |
-          env CTEST_PARALLEL_LEVEL=$(sysctl -n hw.ncpu) CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --target test
+        run: env CTEST_PARALLEL_LEVEL=$(sysctl -n hw.ncpu) ctest --preset ${{ matrix.preset }}
 
   wasm-build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build_type: [ RelWithDebInfo ]
         clang_version: [ 20 ]
-        modules_enable: [ OFF ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup cmake
@@ -88,15 +86,15 @@ jobs:
         run: |
           sudo apt install libclang-rt-${{matrix.clang_version}}-dev-wasm32
           curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sysroot-25.0.tar.gz | tar zxf -
+      - name: Configure
+        run: |
+          cmake --preset wasm \
+            -DCMAKE_INSTALL_PREFIX=$PWD/install \
+            -DSPECBOLT_WASI_SYSROOT=$PWD/wasi-sysroot-25.0
       - name: Build
         run: |
-          mkdir build
-          cmake -S . -B build -G Ninja \
-            -DCMAKE_INSTALL_PREFIX=$PWD/install \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DSPECBOLT_MODULES=${{ matrix.modules_enable }} \
-            -DSPECBOLT_WASM=ON -DSPECBOLT_WASI_SYSROOT=$PWD/wasi-sysroot-25.0
-          cmake --build build
-          cmake --build build --target install
+          cmake --build --preset wasm
+          cmake --install build/wasm
       - name: Deploy
         if: github.ref == 'refs/heads/main'
         uses: jakejarvis/s3-sync-action@master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,24 +2,21 @@
 
 Requires **clang-20+** (for C++26 modules + libc++), CMake 3.30+, Ninja, SDL2, readline.
 
-Default (modules + libc++):
+Presets live in `CMakePresets.json`. The common ones:
 
 ```sh
-CC=clang-20 CXX=clang++-20 cmake -B build/Debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
-cmake --build build/Debug
+cmake --preset debug           # Debug, no modules — works with clang or gcc
+cmake --preset debug-modules   # Debug with C++ modules (needs clang + libc++)
+cmake --preset release         # RelWithDebInfo, no modules (runs zexdoc tests)
+cmake --build --preset debug
+ctest --preset debug
 ```
 
-Modules off (also works with gcc-15):
-
-```sh
-cmake -B build/DebugNoModules -G Ninja -DCMAKE_BUILD_TYPE=Debug -DSPECBOLT_MODULES=OFF
-cmake --build build/DebugNoModules
-```
-
-Run: `./build/Debug/sdl/specbolt_sdl`
-Tests: `ctest --test-dir build/Debug`
+Pick the compiler with `CC=… CXX=…` or by setting `CMAKE_CXX_COMPILER` in a local `CMakeUserPresets.json` (gitignored) that `inherits` from one of the public presets.
 
 The `zexdoc` regression tests are intentionally skipped in `Debug` (too slow); they run in `RelWithDebInfo`.
+
+Run: `./build/debug/sdl/specbolt_sdl`
 
 ## Lint/Format
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,21 @@ if (CAN_USE_LLD)
     add_link_options("-fuse-ld=lld")
 endif ()
 
+# Some clang installs (notably compiler-explorer-style ones) ship libc++ but
+# don't set an rpath, so binaries built against them fail to find libc++.so.1
+# at runtime. If the compiler can resolve libc++.so to an absolute path, embed
+# that directory as an rpath. Harmless on toolchains that don't need it.
+if (NOT SPECBOLT_WASM)
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libc++.so
+            OUTPUT_VARIABLE SPECBOLT_LIBCXX_SO
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET)
+    if (IS_ABSOLUTE "${SPECBOLT_LIBCXX_SO}" AND EXISTS "${SPECBOLT_LIBCXX_SO}")
+        get_filename_component(SPECBOLT_LIBCXX_DIR "${SPECBOLT_LIBCXX_SO}" DIRECTORY)
+        add_link_options("-Wl,-rpath,${SPECBOLT_LIBCXX_DIR}")
+    endif ()
+endif ()
+
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(CPM)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,86 +1,121 @@
 {
-    "version": 6,
-    "cmakeMinimumRequired": {
-        "major": 3,
-        "minor": 30,
-        "patch": 0
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 30,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "_base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}"
     },
-    "configurePresets": [
-        {
-            "name": "_base",
-            "hidden": true,
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/${presetName}"
-        },
-        {
-            "name": "debug",
-            "inherits": "_base",
-            "displayName": "Debug, no modules",
-            "description": "Fastest dev build. Works with clang or gcc.",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "SPECBOLT_MODULES": "OFF"
-            }
-        },
-        {
-            "name": "debug-modules",
-            "inherits": "_base",
-            "displayName": "Debug with C++ modules",
-            "description": "Requires clang-20+ and libc++.",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "SPECBOLT_MODULES": "ON"
-            }
-        },
-        {
-            "name": "release",
-            "inherits": "_base",
-            "displayName": "RelWithDebInfo, no modules",
-            "description": "Optimised build with debug info. Runs the zexdoc regression tests.",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "SPECBOLT_MODULES": "OFF"
-            }
-        },
-        {
-            "name": "release-modules",
-            "inherits": "_base",
-            "displayName": "RelWithDebInfo with C++ modules",
-            "description": "Requires clang-20+ and libc++.",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "SPECBOLT_MODULES": "ON"
-            }
-        },
-        {
-            "name": "wasm",
-            "inherits": "_base",
-            "displayName": "WebAssembly (RelWithDebInfo, no modules)",
-            "description": "WASI build. Pass -DSPECBOLT_WASI_SYSROOT=/path/to/sysroot.",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "SPECBOLT_MODULES": "OFF",
-                "SPECBOLT_WASM": "ON"
-            }
-        }
-    ],
-    "buildPresets": [
-        { "name": "debug", "configurePreset": "debug" },
-        { "name": "debug-modules", "configurePreset": "debug-modules" },
-        { "name": "release", "configurePreset": "release" },
-        { "name": "release-modules", "configurePreset": "release-modules" },
-        { "name": "wasm", "configurePreset": "wasm" }
-    ],
-    "testPresets": [
-        {
-            "name": "_test-base",
-            "hidden": true,
-            "output": { "outputOnFailure": true },
-            "execution": { "noTestsAction": "error" }
-        },
-        { "name": "debug", "configurePreset": "debug", "inherits": "_test-base" },
-        { "name": "debug-modules", "configurePreset": "debug-modules", "inherits": "_test-base" },
-        { "name": "release", "configurePreset": "release", "inherits": "_test-base" },
-        { "name": "release-modules", "configurePreset": "release-modules", "inherits": "_test-base" }
-    ]
+    {
+      "name": "debug",
+      "inherits": "_base",
+      "displayName": "Debug, no modules",
+      "description": "Fastest dev build. Works with clang or gcc.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "SPECBOLT_MODULES": "OFF"
+      }
+    },
+    {
+      "name": "debug-modules",
+      "inherits": "_base",
+      "displayName": "Debug with C++ modules",
+      "description": "Requires clang-20+ and libc++.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "SPECBOLT_MODULES": "ON"
+      }
+    },
+    {
+      "name": "release",
+      "inherits": "_base",
+      "displayName": "RelWithDebInfo, no modules",
+      "description": "Optimised build with debug info. Runs the zexdoc regression tests.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "SPECBOLT_MODULES": "OFF"
+      }
+    },
+    {
+      "name": "release-modules",
+      "inherits": "_base",
+      "displayName": "RelWithDebInfo with C++ modules",
+      "description": "Requires clang-20+ and libc++.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "SPECBOLT_MODULES": "ON"
+      }
+    },
+    {
+      "name": "wasm",
+      "inherits": "_base",
+      "displayName": "WebAssembly (RelWithDebInfo, no modules)",
+      "description": "WASI build. Pass -DSPECBOLT_WASI_SYSROOT=/path/to/sysroot.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "SPECBOLT_MODULES": "OFF",
+        "SPECBOLT_WASM": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "debug-modules",
+      "configurePreset": "debug-modules"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "release-modules",
+      "configurePreset": "release-modules"
+    },
+    {
+      "name": "wasm",
+      "configurePreset": "wasm"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "_test-base",
+      "hidden": true,
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error"
+      }
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "inherits": "_test-base"
+    },
+    {
+      "name": "debug-modules",
+      "configurePreset": "debug-modules",
+      "inherits": "_test-base"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release",
+      "inherits": "_test-base"
+    },
+    {
+      "name": "release-modules",
+      "configurePreset": "release-modules",
+      "inherits": "_test-base"
+    }
+  ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,86 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 30,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "_base",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}"
+        },
+        {
+            "name": "debug",
+            "inherits": "_base",
+            "displayName": "Debug, no modules",
+            "description": "Fastest dev build. Works with clang or gcc.",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "SPECBOLT_MODULES": "OFF"
+            }
+        },
+        {
+            "name": "debug-modules",
+            "inherits": "_base",
+            "displayName": "Debug with C++ modules",
+            "description": "Requires clang-20+ and libc++.",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "SPECBOLT_MODULES": "ON"
+            }
+        },
+        {
+            "name": "release",
+            "inherits": "_base",
+            "displayName": "RelWithDebInfo, no modules",
+            "description": "Optimised build with debug info. Runs the zexdoc regression tests.",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "SPECBOLT_MODULES": "OFF"
+            }
+        },
+        {
+            "name": "release-modules",
+            "inherits": "_base",
+            "displayName": "RelWithDebInfo with C++ modules",
+            "description": "Requires clang-20+ and libc++.",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "SPECBOLT_MODULES": "ON"
+            }
+        },
+        {
+            "name": "wasm",
+            "inherits": "_base",
+            "displayName": "WebAssembly (RelWithDebInfo, no modules)",
+            "description": "WASI build. Pass -DSPECBOLT_WASI_SYSROOT=/path/to/sysroot.",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "SPECBOLT_MODULES": "OFF",
+                "SPECBOLT_WASM": "ON"
+            }
+        }
+    ],
+    "buildPresets": [
+        { "name": "debug", "configurePreset": "debug" },
+        { "name": "debug-modules", "configurePreset": "debug-modules" },
+        { "name": "release", "configurePreset": "release" },
+        { "name": "release-modules", "configurePreset": "release-modules" },
+        { "name": "wasm", "configurePreset": "wasm" }
+    ],
+    "testPresets": [
+        {
+            "name": "_test-base",
+            "hidden": true,
+            "output": { "outputOnFailure": true },
+            "execution": { "noTestsAction": "error" }
+        },
+        { "name": "debug", "configurePreset": "debug", "inherits": "_test-base" },
+        { "name": "debug-modules", "configurePreset": "debug-modules", "inherits": "_test-base" },
+        { "name": "release", "configurePreset": "release", "inherits": "_test-base" },
+        { "name": "release-modules", "configurePreset": "release-modules", "inherits": "_test-base" }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -24,19 +24,21 @@ specbolt is structured into several key components:
 
 ### Building
 
+The simplest path is via CMake presets (see `CMakePresets.json` for the list):
+
 ```bash
-# Configure with modules support
-cmake -B build/Debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DSPECBOLT_MODULES=ON
+# Configure, build, test
+cmake --preset debug              # Debug, no modules — works with clang or gcc
+cmake --build --preset debug
+ctest --preset debug
 
-# Configure without modules (recommended for most development)
-cmake -B build/DebugNoModules -G Ninja -DCMAKE_BUILD_TYPE=Debug -DSPECBOLT_MODULES=OFF
-
-# Build (no modules version)
-cmake --build build/DebugNoModules
-
-# Run (no modules version)
-./build/DebugNoModules/sdl/specbolt_sdl
+# Run
+./build/debug/sdl/specbolt_sdl
 ```
+
+Other useful presets: `debug-modules` (needs clang + libc++), `release` (RelWithDebInfo, runs the zexdoc regression tests), and `release-modules`.
+
+To pin a specific compiler, set `CC`/`CXX` or create a local `CMakeUserPresets.json` (gitignored) that inherits a public preset and overrides `CMAKE_CXX_COMPILER`.
 
 ### Web/WASM Build
 

--- a/cmake/pedantic-and-modern.cmake
+++ b/cmake/pedantic-and-modern.cmake
@@ -9,6 +9,14 @@ else ()
 
     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         target_compile_definitions(opt_pedantic INTERFACE "_LIBCPP_ENABLE_NODISCARD")
+        # Catch2's TEST_CASE/SECTION rely on __COUNTER__. Recent clang (≥21 on
+        # homebrew) treats this as a C2y extension warning even in C++ mode,
+        # which -Werror turns into a build failure.
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag(-Wc2y-extensions HAVE_WC2Y_EXTENSIONS)
+        if (HAVE_WC2Y_EXTENSIONS)
+            target_compile_options(opt_pedantic INTERFACE "-Wno-c2y-extensions")
+        endif ()
     endif ()
 endif ()
 


### PR DESCRIPTION
## Summary
- New `CMakePresets.json` with `debug` / `debug-modules` / `release` / `release-modules` / `wasm` presets, each with paired build/test presets. Build dirs at `build/<preset>`.
- `CMakeLists.txt` embeds libc++ RUNPATH when the compiler reports an absolute path to `libc++.so`. Fixes compiler-explorer-style installs that ship libc++ without an rpath, so binaries find `libc++.so.1` at runtime with no `LD_LIBRARY_PATH` gymnastics. Harmless on toolchains that don't need it.
- All CI jobs (Linux/macOS/wasm) migrated to use `cmake --preset`; matrix axes collapse to a single `preset` value. macOS keeps its brew/sysroot `-D` flags; wasm takes its install prefix and WASI sysroot via `-D`.
- `CLAUDE.md` and `README.md` lead with the presets workflow.

## Test plan
- [x] gcc-15 + `cmake --preset debug` → 164/164 build, 6/6 tests
- [x] gcc-15 + `cmake --preset release` → 9/9 tests including 3 × zexdoc
- [x] CE clang-21.1.0 manual configure → tests pass with NO `LD_LIBRARY_PATH` (RUNPATH baked in)
- [x] clang-trunk via local user preset → both \`debug\` and \`debug-modules\` paths pass
- [ ] CI: apt-clang-20 Linux matrix (all four presets)
- [ ] CI: macOS llvm/sysroot flags forwarded correctly to `--preset`
- [ ] CI: wasm install path (\`build/wasm\` + \`cmake --install\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)