### PR TITLE
Fix DD/FD-prefixed EX DE,HL in v2/v3

### DIFF
--- a/z80/test/OpcodeTests.cpp
+++ b/z80/test/OpcodeTests.cpp
@@ -1026,6 +1026,19 @@ struct OpcodeTester {
         CHECK(z80.flags() == (Flags::Zero() | Flags::HalfCarry()));
       } // not supported in the old code
     }
+    SECTION("ex de, hl") {
+      if (use_new_code) {
+        regs.set(RegisterFile::R16::DE, 0x0102);
+        regs.set(RegisterFile::R16::HL, 0xcafe);
+        regs.set(RegisterFile::R16::IX, 0xabcd);
+        run(0xdd, 0xeb);
+        CHECK(z80.pc() == 2);
+        CHECK(z80.cycle_count() == 8);
+        CHECK(regs.get(RegisterFile::R16::DE) == 0xcafe);
+        CHECK(regs.get(RegisterFile::R16::HL) == 0x0102);
+        CHECK(regs.get(RegisterFile::R16::IX) == 0xabcd);
+      }
+    }
     SECTION("inc ix") {
       regs.set(RegisterFile::R16::IX, 0x12ff);
       run(0xdd, 0x23); // inc ix
@@ -1116,6 +1129,19 @@ struct OpcodeTester {
 
   void fd_prefix() {
     // Assumed that if we turned HL->IX for all the 0xdd prefix, then 0xfd works if one of them works...
+    SECTION("ex de, hl") {
+      if (use_new_code) {
+        regs.set(RegisterFile::R16::DE, 0x0102);
+        regs.set(RegisterFile::R16::HL, 0xcafe);
+        regs.set(RegisterFile::R16::IY, 0xabcd);
+        run(0xfd, 0xeb);
+        CHECK(z80.pc() == 2);
+        CHECK(z80.cycle_count() == 8);
+        CHECK(regs.get(RegisterFile::R16::DE) == 0xcafe);
+        CHECK(regs.get(RegisterFile::R16::HL) == 0x0102);
+        CHECK(regs.get(RegisterFile::R16::IY) == 0xabcd);
+      }
+    }
     SECTION("inc iy") {
       regs.set(RegisterFile::R16::IY, 0x12ff);
       run(0xfd, 0x23); // inc iy

--- a/z80/v2/Z80Impl.hpp
+++ b/z80/v2/Z80Impl.hpp
@@ -596,8 +596,9 @@ constexpr auto instruction<opcode> = Op<"ex (sp), "s + IndexReg<opcode.hl_set>::
 
 template<Opcode opcode>
   requires(opcode.x == 3 && opcode.z == 3 && opcode.y == 5)
-constexpr auto instruction<opcode> = Op<"ex de, "s + IndexReg<opcode.hl_set>::name,
-    [](Z80 &z80) { z80.regs().ex(RegisterFile::R16::DE, IndexReg<opcode.hl_set>::highlow); }>{};
+// DD/FD leave EX DE,HL unaffected on real Z80s.
+constexpr auto instruction<opcode> =
+    Op<"ex de, hl", [](Z80 &z80) { z80.regs().ex(RegisterFile::R16::DE, RegisterFile::R16::HL); }>{};
 
 template<Opcode opcode>
   requires(opcode.x == 3 && opcode.z == 3 && opcode.y == 6)

--- a/z80/v2/test/DisassemblerTest.cpp
+++ b/z80/v2/test/DisassemblerTest.cpp
@@ -332,7 +332,9 @@ TEST_CASE("Opcode generation tests") {
     CHECK(dis(0xdd, 0xe5) == "push ix");
     CHECK(dis(0xdd, 0x09) == "add ix, bc");
     CHECK(dis(0xdd, 0x22, 0xad, 0xba) == "ld (0xbaad), ix");
+    CHECK(dis(0xdd, 0xeb) == "ex de, hl");
   }
+  SECTION("Test fd prefixes") { CHECK(dis(0xfd, 0xeb) == "ex de, hl"); }
   SECTION("Test ddcb prefixes") {
     CHECK(dis(0xdd, 0xcb, 0xff, 0x06) == "rlc (ix-0x01)");
     CHECK(dis(0xdd, 0xcb, 0x23, 0xf6) == "set 6, (ix+0x23)");

--- a/z80/v3/MakeZ80.cpp
+++ b/z80/v3/MakeZ80.cpp
@@ -315,9 +315,9 @@ Op match_op(const Opcode opcode) {
             std::format("set(R16::{},  static_cast<std::uint16_t>(sp_old_low | sp_old_high << 8));",
                 upper(opcode.reg_set.index_reg))}};
 
+  // DD/FD leave EX DE,HL unaffected on real Z80s.
   if (opcode.x == 3 && opcode.z == 3 && opcode.y == 5)
-    return {std::format("ex de, {}", opcode.reg_set.index_reg),
-        {std::format("regs_.ex(R16::DE, R16::{});", upper(opcode.reg_set.index_reg))}};
+    return {"ex de, hl", {"regs_.ex(R16::DE, R16::HL);"}};
   if (opcode.x == 3 && opcode.z == 3 && opcode.y == 6)
     return {"di", {"iff1_ = iff2_ = false;"}};
   if (opcode.x == 3 && opcode.z == 3 && opcode.y == 7)

--- a/z80/v3/test/DisassemblerTest.cpp
+++ b/z80/v3/test/DisassemblerTest.cpp
@@ -332,7 +332,9 @@ TEST_CASE("Opcode generation tests") {
     CHECK(dis(0xdd, 0xe5) == "push ix");
     CHECK(dis(0xdd, 0x09) == "add ix, bc");
     CHECK(dis(0xdd, 0x22, 0xad, 0xba) == "ld (0xbaad), ix");
+    CHECK(dis(0xdd, 0xeb) == "ex de, hl");
   }
+  SECTION("Test fd prefixes") { CHECK(dis(0xfd, 0xeb) == "ex de, hl"); }
   SECTION("Test ddcb prefixes") {
     CHECK(dis(0xdd, 0xcb, 0xff, 0x06) == "rlc (ix-0x01)");
     CHECK(dis(0xdd, 0xcb, 0x23, 0xf6) == "set 6, (ix+0x23)");


### PR DESCRIPTION
## Summary

- keep DD/FD-prefixed `EX DE,HL` operating on HL in v2 and v3
- emit and disassemble the unaffected mnemonic correctly
- add execution regressions proving DE swaps with HL while IX/IY stay unchanged

## Test plan

- [x] focused pre-commit hooks, including clang-format 20.1.6
- [x] build `z80_test`, `z80_v2_test`, and `z80_v3_test` with Clang 20.1.8
- [x] `Z80 v1 vs v2 Unit Tests`
- [x] `Z80 v2 Unit Tests`
- [x] `Z80 v3 Unit Tests`
- [x] `git diff --check`

The local CMake configure used a temporary SDL2 target stub because SDL2 is not installed in this environment; none of the three tested Z80 targets links that UI dependency.

Closes #39
